### PR TITLE
refactor: remove unnecessary typedefs

### DIFF
--- a/examples/dynamic_array_test.c
+++ b/examples/dynamic_array_test.c
@@ -12,7 +12,7 @@
 
 int main(void)
 {
-    darr *da = darr_malloc();
+    struct darr_t *da = darr_malloc();
     /*
      * also valid:
      * struct darr_t *da = darr_malloc();

--- a/examples/ht_test.c
+++ b/examples/ht_test.c
@@ -11,23 +11,19 @@
 
 
 /* wrapper functions when key and val are string */
-void ht_sset(ht *table, const char *key, const char *val)
+void ht_sset(struct ht_t *table, const char *key, const char *val)
 {
     ht_set(table, key, strlen(key) + 1, val, strlen(val) + 1, NULL);
 }
 
-char *ht_sget(ht *table, const char *key)
+char *ht_sget(struct ht_t *table, const char *key)
 {
     return ht_get(table, key, strlen(key) + 1);
 }
 
 int main(void)
 {
-    ht *table = ht_malloc(32);
-    /*
-     * also valid:
-     * struct ht_t *table = ht_malloc(32);
-     */
+    struct ht_t *table = ht_malloc(32);
 
     char *key1 = "my key"; 
     char *val1 = "hello world!";

--- a/nicc.h
+++ b/nicc.h
@@ -23,13 +23,6 @@
 #include <stdint.h>
 
 
-/* types */
-typedef struct darr_t darr;
-
-typedef struct ht_t ht;
-
-typedef struct ht_item_t ht_item;
-
 /* darr functions */
 struct darr_t *darr_malloc(void);
 void darr_free(struct darr_t *da);


### PR DESCRIPTION
"It’s a mistake to use typedef for structures and pointers. ... In general, a pointer, or a struct that has elements that can reasonably be directly accessed should never be a typedef." - https://www.kernel.org/doc/html/v4.10/process/coding-style.html#typedefs